### PR TITLE
More robust exception parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.11.1] - 2021-10-07
+
+### Changed
+
+- Explicitly naming table constraints on creation (using the default Postgres names, so we don't break existing DBs)
+- Using PSQLException to parse exception messages
+
 ## [1.11.0] - 2021-09-12
 
 ### Changed

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ plugins {
     id 'java-library'
 }
 
-version = "1.11.0"
+version = "1.11.1"
 
 repositories {
     mavenCentral()

--- a/src/main/java/io/supertokens/storage/postgresql/queries/EmailPasswordQueries.java
+++ b/src/main/java/io/supertokens/storage/postgresql/queries/EmailPasswordQueries.java
@@ -48,8 +48,7 @@ public class EmailPasswordQueries {
 
     static String getQueryToCreatePasswordResetTokensTable(Start start) {
         // @formatter:off
-        String 
-        passwordResetTokensTable = Config.getConfig(start).getPasswordResetTokensTable();
+        String passwordResetTokensTable = Config.getConfig(start).getPasswordResetTokensTable();
         return "CREATE TABLE IF NOT EXISTS " + passwordResetTokensTable + " ("
                 + "user_id CHAR(36) NOT NULL,"
                 + "token VARCHAR(128) NOT NULL CONSTRAINT " + passwordResetTokensTable + "_token_key UNIQUE,"

--- a/src/main/java/io/supertokens/storage/postgresql/queries/EmailPasswordQueries.java
+++ b/src/main/java/io/supertokens/storage/postgresql/queries/EmailPasswordQueries.java
@@ -36,17 +36,29 @@ import java.util.List;
 public class EmailPasswordQueries {
 
     static String getQueryToCreateUsersTable(Start start) {
-        return "CREATE TABLE IF NOT EXISTS " + Config.getConfig(start).getEmailPasswordUsersTable() + " ("
-                + "user_id CHAR(36) NOT NULL," + "email VARCHAR(256) NOT NULL UNIQUE,"
-                + "password_hash VARCHAR(128) NOT NULL," + "time_joined BIGINT NOT NULL," + "PRIMARY KEY (user_id));";
+        // @formatter:off
+        String emailPasswordUsersTable = Config.getConfig(start).getEmailPasswordUsersTable();
+        return "CREATE TABLE IF NOT EXISTS " + emailPasswordUsersTable + " ("
+                + "user_id CHAR(36) NOT NULL,"
+                + "email VARCHAR(256) NOT NULL CONSTRAINT " + emailPasswordUsersTable + "_email_key UNIQUE,"
+                + "password_hash VARCHAR(128) NOT NULL," + "time_joined BIGINT NOT NULL," 
+                + "CONSTRAINT " + emailPasswordUsersTable + "_pkey PRIMARY KEY (user_id));";
+        // @formatter:on
     }
 
     static String getQueryToCreatePasswordResetTokensTable(Start start) {
-        return "CREATE TABLE IF NOT EXISTS " + Config.getConfig(start).getPasswordResetTokensTable() + " ("
-                + "user_id CHAR(36) NOT NULL," + "token VARCHAR(128) NOT NULL UNIQUE," + "token_expiry BIGINT NOT NULL,"
-                + "PRIMARY KEY (user_id, token)," + "FOREIGN KEY (user_id) REFERENCES "
-                + Config.getConfig(start).getEmailPasswordUsersTable()
-                + "(user_id) ON DELETE CASCADE ON UPDATE CASCADE);";
+        // @formatter:off
+        String 
+        passwordResetTokensTable = Config.getConfig(start).getPasswordResetTokensTable();
+        return "CREATE TABLE IF NOT EXISTS " + passwordResetTokensTable + " ("
+                + "user_id CHAR(36) NOT NULL,"
+                + "token VARCHAR(128) NOT NULL CONSTRAINT " + passwordResetTokensTable + "_token_key UNIQUE,"
+                + "token_expiry BIGINT NOT NULL,"
+                + "CONSTRAINT " + passwordResetTokensTable + "_pkey PRIMARY KEY (user_id, token),"
+                + ("CONSTRAINT " + passwordResetTokensTable + "_user_id_fkey FOREIGN KEY (user_id)" 
+                    + " REFERENCES " + Config.getConfig(start).getEmailPasswordUsersTable() + "(user_id)" 
+                    + " ON DELETE CASCADE ON UPDATE CASCADE);");
+        // @formatter:on
     }
 
     static String getQueryToCreatePasswordResetTokenExpiryIndex(Start start) {

--- a/src/main/java/io/supertokens/storage/postgresql/queries/EmailVerificationQueries.java
+++ b/src/main/java/io/supertokens/storage/postgresql/queries/EmailVerificationQueries.java
@@ -33,15 +33,25 @@ import java.util.List;
 public class EmailVerificationQueries {
 
     static String getQueryToCreateEmailVerificationTable(Start start) {
-        return "CREATE TABLE IF NOT EXISTS " + Config.getConfig(start).getEmailVerificationTable() + " ("
-                + "user_id VARCHAR(128) NOT NULL," + "email VARCHAR(256) NOT NULL," + "PRIMARY KEY (user_id, email));";
+        // @formatter:off
+        String emailVerificationTable = Config.getConfig(start).getEmailVerificationTable();
+        return "CREATE TABLE IF NOT EXISTS " + emailVerificationTable + " ("
+                + "user_id VARCHAR(128) NOT NULL," 
+                + "email VARCHAR(256) NOT NULL," 
+                + "CONSTRAINT " + emailVerificationTable + "_pkey PRIMARY KEY (user_id, email));";
+        // @formatter:on
     }
 
     static String getQueryToCreateEmailVerificationTokensTable(Start start) {
-        return "CREATE TABLE IF NOT EXISTS " + Config.getConfig(start).getEmailVerificationTokensTable() + " ("
-                + "user_id VARCHAR(128) NOT NULL," + "email VARCHAR(256) NOT NULL,"
-                + "token VARCHAR(128) NOT NULL UNIQUE," + "token_expiry BIGINT NOT NULL,"
-                + "PRIMARY KEY (user_id, email, token))";
+        // @formatter:off
+        String emailVerificationTokensTable = Config.getConfig(start).getEmailVerificationTokensTable();
+        return "CREATE TABLE IF NOT EXISTS " + emailVerificationTokensTable + " ("
+                + "user_id VARCHAR(128) NOT NULL," 
+                + "email VARCHAR(256) NOT NULL,"
+                + "token VARCHAR(128) NOT NULL CONSTRAINT " + emailVerificationTokensTable + "_token_key UNIQUE,"
+                + "token_expiry BIGINT NOT NULL,"
+                + "CONSTRAINT " + emailVerificationTokensTable + "_pkey PRIMARY KEY (user_id, email, token))";
+        // @formatter:on
     }
 
     static String getQueryToCreateEmailVerificationTokenExpiryIndex(Start start) {

--- a/src/main/java/io/supertokens/storage/postgresql/queries/GeneralQueries.java
+++ b/src/main/java/io/supertokens/storage/postgresql/queries/GeneralQueries.java
@@ -54,9 +54,13 @@ public class GeneralQueries {
     }
 
     static String getQueryToCreateUsersTable(Start start) {
+        // @formatter:off
         return "CREATE TABLE IF NOT EXISTS " + Config.getConfig(start).getUsersTable() + " ("
-                + "user_id CHAR(36) NOT NULL," + "recipe_id VARCHAR(128) NOT NULL," + "time_joined BIGINT NOT NULL,"
-                + "PRIMARY KEY (user_id));";
+                + "user_id CHAR(36) NOT NULL," 
+                + "recipe_id VARCHAR(128) NOT NULL," 
+                + "time_joined BIGINT NOT NULL,"
+                + "CONSTRAINT " + Config.getConfig(start).getUsersTable() + "_pkey PRIMARY KEY (user_id));";
+        // @formatter:on
     }
 
     static String getQueryToCreateUserPaginationIndex(Start start) {
@@ -65,8 +69,13 @@ public class GeneralQueries {
     }
 
     private static String getQueryToCreateKeyValueTable(Start start) {
-        return "CREATE TABLE IF NOT EXISTS " + Config.getConfig(start).getKeyValueTable() + " (" + "name VARCHAR(128),"
-                + "value TEXT," + "created_at_time BIGINT ," + "PRIMARY KEY(name)" + " );";
+        // @formatter:off
+        return "CREATE TABLE IF NOT EXISTS " + Config.getConfig(start).getKeyValueTable() + " (" 
+                + "name VARCHAR(128),"
+                + "value TEXT," 
+                + "created_at_time BIGINT ," 
+                + "CONSTRAINT " + Config.getConfig(start).getKeyValueTable() + "_pkey PRIMARY KEY(name)" + " );";
+        // @formatter:on
     }
 
     public static void createTablesIfNotExists(Start start) throws SQLException {

--- a/src/main/java/io/supertokens/storage/postgresql/queries/JWTSigningQueries.java
+++ b/src/main/java/io/supertokens/storage/postgresql/queries/JWTSigningQueries.java
@@ -40,9 +40,14 @@ public class JWTSigningQueries {
          * defined
          * keys in the future.
          */
+        // @formatter:off
         return "CREATE TABLE IF NOT EXISTS " + Config.getConfig(start).getJWTSigningKeysTable() + " ("
-                + "key_id VARCHAR(255) NOT NULL," + "key_string TEXT NOT NULL," + "algorithm VARCHAR(10) NOT NULL,"
-                + "created_at BIGINT," + "PRIMARY KEY(key_id));";
+                + "key_id VARCHAR(255) NOT NULL," 
+                + "key_string TEXT NOT NULL," 
+                + "algorithm VARCHAR(10) NOT NULL,"
+                + "created_at BIGINT," 
+                + "CONSTRAINT " + Config.getConfig(start).getJWTSigningKeysTable() + "_pkey PRIMARY KEY(key_id));";
+        // @formatter:on
     }
 
     public static List<JWTSigningKeyInfo> getJWTSigningKeys_Transaction(Start start, Connection con)

--- a/src/main/java/io/supertokens/storage/postgresql/queries/SessionQueries.java
+++ b/src/main/java/io/supertokens/storage/postgresql/queries/SessionQueries.java
@@ -38,16 +38,27 @@ import java.util.List;
 public class SessionQueries {
 
     public static String getQueryToCreateSessionInfoTable(Start start) {
+        // @formatter:off
         return "CREATE TABLE IF NOT EXISTS " + Config.getConfig(start).getSessionInfoTable() + " ("
-                + "session_handle VARCHAR(255) NOT NULL," + "user_id VARCHAR(128) NOT NULL,"
-                + "refresh_token_hash_2 VARCHAR(128) NOT NULL," + "session_data TEXT," + "expires_at BIGINT  NOT NULL,"
-                + "created_at_time BIGINT NOT NULL," + "jwt_user_payload TEXT," + "PRIMARY KEY(session_handle)" + " );";
+                + "session_handle VARCHAR(255) NOT NULL," 
+                + "user_id VARCHAR(128) NOT NULL,"
+                + "refresh_token_hash_2 VARCHAR(128) NOT NULL," 
+                + "session_data TEXT," 
+                + "expires_at BIGINT NOT NULL,"
+                + "created_at_time BIGINT NOT NULL," 
+                + "jwt_user_payload TEXT," 
+                + "CONSTRAINT " + Config.getConfig(start).getSessionInfoTable() + "_pkey PRIMARY KEY(session_handle)" + " );";
+        // @formatter:on
 
     }
 
     static String getQueryToCreateAccessTokenSigningKeysTable(Start start) {
+        // @formatter:off
         return "CREATE TABLE IF NOT EXISTS " + Config.getConfig(start).getAccessTokenSigningKeysTable() + " ("
-                + "created_at_time BIGINT NOT NULL," + "value TEXT," + "PRIMARY KEY(created_at_time)" + " );";
+                + "created_at_time BIGINT NOT NULL," 
+                + "value TEXT," 
+                + "CONSTRAINT " + Config.getConfig(start).getAccessTokenSigningKeysTable() + "_pkey PRIMARY KEY(created_at_time)" + " );";
+        // @formatter:on
     }
 
     public static void createNewSession(Start start, String sessionHandle, String userId, String refreshTokenHash2,

--- a/src/main/java/io/supertokens/storage/postgresql/queries/ThirdPartyQueries.java
+++ b/src/main/java/io/supertokens/storage/postgresql/queries/ThirdPartyQueries.java
@@ -36,10 +36,16 @@ import java.util.List;
 public class ThirdPartyQueries {
 
     static String getQueryToCreateUsersTable(Start start) {
-        return "CREATE TABLE IF NOT EXISTS " + Config.getConfig(start).getThirdPartyUsersTable() + " ("
-                + "third_party_id VARCHAR(28) NOT NULL," + "third_party_user_id VARCHAR(128) NOT NULL,"
-                + "user_id CHAR(36) NOT NULL UNIQUE," + "email VARCHAR(256) NOT NULL," + "time_joined BIGINT NOT NULL,"
-                + "PRIMARY KEY (third_party_id, third_party_user_id));";
+        // @formatter:off
+        String thirdPartyUsersTable = Config.getConfig(start).getThirdPartyUsersTable();
+        return "CREATE TABLE IF NOT EXISTS " + thirdPartyUsersTable + " ("
+                + "third_party_id VARCHAR(28) NOT NULL," 
+                + "third_party_user_id VARCHAR(128) NOT NULL,"
+                + "user_id CHAR(36) NOT NULL CONSTRAINT " + thirdPartyUsersTable + "_user_id_key UNIQUE,"
+                + "email VARCHAR(256) NOT NULL," 
+                + "time_joined BIGINT NOT NULL," 
+                + "CONSTRAINT " + thirdPartyUsersTable + "_pkey PRIMARY KEY (third_party_id, third_party_user_id));";
+        // @formatter:on
     }
 
     public static void signUp(Start start, io.supertokens.pluginInterface.thirdparty.UserInfo userInfo)

--- a/src/test/java/io/supertokens/storage/postgresql/test/ExceptionParsingTest.java
+++ b/src/test/java/io/supertokens/storage/postgresql/test/ExceptionParsingTest.java
@@ -1,0 +1,404 @@
+/*
+ *    Copyright (c) 2020, VRAI Labs and/or its affiliates. All rights reserved.
+ *
+ *    This software is licensed under the Apache License, Version 2.0 (the
+ *    "License") as published by the Apache Software Foundation.
+ *
+ *    You may not use this file except in compliance with the License. You may
+ *    obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *    License for the specific language governing permissions and limitations
+ *    under the License.
+ *
+ */
+
+package io.supertokens.storage.postgresql.test;
+
+import static junit.framework.TestCase.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import java.io.UnsupportedEncodingException;
+import java.security.InvalidAlgorithmParameterException;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import java.security.SignatureException;
+import java.security.spec.InvalidKeySpecException;
+
+import javax.crypto.BadPaddingException;
+import javax.crypto.IllegalBlockSizeException;
+import javax.crypto.NoSuchPaddingException;
+
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestRule;
+
+import io.supertokens.ProcessState;
+import io.supertokens.pluginInterface.RECIPE_ID;
+import io.supertokens.pluginInterface.emailpassword.PasswordResetTokenInfo;
+import io.supertokens.pluginInterface.emailpassword.UserInfo;
+import io.supertokens.pluginInterface.emailpassword.exceptions.DuplicateEmailException;
+import io.supertokens.pluginInterface.emailpassword.exceptions.DuplicatePasswordResetTokenException;
+import io.supertokens.pluginInterface.emailpassword.exceptions.DuplicateUserIdException;
+import io.supertokens.pluginInterface.emailpassword.exceptions.UnknownUserIdException;
+import io.supertokens.pluginInterface.emailverification.EmailVerificationTokenInfo;
+import io.supertokens.pluginInterface.emailverification.exception.DuplicateEmailVerificationTokenException;
+import io.supertokens.pluginInterface.exceptions.StorageQueryException;
+import io.supertokens.pluginInterface.exceptions.StorageTransactionLogicException;
+import io.supertokens.pluginInterface.jwt.JWTSymmetricSigningKeyInfo;
+import io.supertokens.pluginInterface.jwt.exceptions.DuplicateKeyIdException;
+import io.supertokens.pluginInterface.jwt.sqlstorage.JWTRecipeSQLStorage;
+import io.supertokens.pluginInterface.thirdparty.exception.DuplicateThirdPartyUserException;
+import io.supertokens.storageLayer.StorageLayer;
+
+public class ExceptionParsingTest {
+    @Rule
+    public TestRule watchman = Utils.getOnFailure();
+
+    @AfterClass
+    public static void afterTesting() {
+        Utils.afterTesting();
+    }
+
+    @Before
+    public void beforeEach() {
+        Utils.reset();
+    }
+
+    @Test
+    public void thirdPartySignupExceptions() throws InterruptedException, StorageQueryException,
+            NoSuchAlgorithmException, InvalidKeyException, SignatureException, InvalidAlgorithmParameterException,
+            NoSuchPaddingException, BadPaddingException, UnsupportedEncodingException, InvalidKeySpecException,
+            IllegalBlockSizeException, StorageTransactionLogicException, DuplicateThirdPartyUserException,
+            io.supertokens.pluginInterface.thirdparty.exception.DuplicateUserIdException {
+        {
+            String[] args = { "../" };
+            TestingProcessManager.TestingProcess process = TestingProcessManager.start(args);
+            assertNotNull(process.checkOrWaitForEvent(ProcessState.PROCESS_STATE.STARTED));
+
+            var storage = StorageLayer.getThirdPartyStorage(process.getProcess());
+
+            String userId = "userId";
+            String userId2 = "userId2";
+            String tpId = "gugli";
+            String thirdPartyUserId = "tp_userId";
+            String userEmail = "useremail@asdf.fdas";
+
+            var tp = new io.supertokens.pluginInterface.thirdparty.UserInfo.ThirdParty(tpId, thirdPartyUserId);
+            var info = new io.supertokens.pluginInterface.thirdparty.UserInfo(userId, userEmail, tp,
+                    System.currentTimeMillis());
+            storage.signUp(info);
+            try {
+                storage.signUp(info);
+            } catch (io.supertokens.pluginInterface.thirdparty.exception.DuplicateUserIdException ex) {
+                // expected
+            }
+            var info2 = new io.supertokens.pluginInterface.thirdparty.UserInfo(userId2, userEmail, tp,
+                    System.currentTimeMillis());
+
+            try {
+                storage.signUp(info2);
+            } catch (DuplicateThirdPartyUserException ex) {
+                // expected
+            }
+
+            assertEquals(storage.getUsersCount(new RECIPE_ID[] { RECIPE_ID.THIRD_PARTY }), 1);
+
+            process.kill();
+            assertNotNull(process.checkOrWaitForEvent(ProcessState.PROCESS_STATE.STOPPED));
+        }
+    }
+
+    @Test
+    public void emailPasswordSignupExceptions()
+            throws InterruptedException, StorageQueryException, NoSuchAlgorithmException, InvalidKeyException,
+            SignatureException, InvalidAlgorithmParameterException, NoSuchPaddingException, BadPaddingException,
+            UnsupportedEncodingException, InvalidKeySpecException, IllegalBlockSizeException,
+            StorageTransactionLogicException, DuplicateUserIdException, DuplicateEmailException {
+        {
+            String[] args = { "../" };
+            TestingProcessManager.TestingProcess process = TestingProcessManager.start(args);
+            assertNotNull(process.checkOrWaitForEvent(ProcessState.PROCESS_STATE.STARTED));
+
+            var storage = StorageLayer.getEmailPasswordStorage(process.getProcess());
+
+            String userId = "userId";
+            String userId2 = "userId2";
+            String pwHash = "fakehash";
+            String userEmail = "useremail@asdf.fdas";
+
+            var info = new UserInfo(userId, userEmail, pwHash, System.currentTimeMillis());
+            storage.signUp(info);
+            try {
+                storage.signUp(info);
+            } catch (DuplicateUserIdException ex) {
+                // expected
+            }
+            var info2 = new UserInfo(userId2, userEmail, pwHash, System.currentTimeMillis());
+
+            try {
+                storage.signUp(info2);
+            } catch (DuplicateEmailException ex) {
+                // expected
+            }
+
+            assertEquals(storage.getUsersCount(new RECIPE_ID[] { RECIPE_ID.EMAIL_PASSWORD }), 1);
+
+            process.kill();
+            assertNotNull(process.checkOrWaitForEvent(ProcessState.PROCESS_STATE.STOPPED));
+        }
+    }
+
+    @Test
+    public void updateUsersEmail_TransactionExceptions()
+            throws InterruptedException, StorageQueryException, NoSuchAlgorithmException, InvalidKeyException,
+            SignatureException, InvalidAlgorithmParameterException, NoSuchPaddingException, BadPaddingException,
+            UnsupportedEncodingException, InvalidKeySpecException, IllegalBlockSizeException,
+            StorageTransactionLogicException, DuplicateUserIdException, DuplicateEmailException {
+        {
+            String[] args = { "../" };
+            TestingProcessManager.TestingProcess process = TestingProcessManager.start(args);
+            assertNotNull(process.checkOrWaitForEvent(ProcessState.PROCESS_STATE.STARTED));
+
+            var storage = StorageLayer.getEmailPasswordStorage(process.getProcess());
+
+            String userId = "userId";
+            String userId2 = "userId2";
+            String pwHash = "fakehash";
+            String userEmail = "useremail@asdf.fdas";
+            String userEmail2 = "useremail2@asdf.fdas";
+            String userEmail3 = "useremail3@asdf.fdas";
+
+            var info = new UserInfo(userId, userEmail, pwHash, System.currentTimeMillis());
+            var info2 = new UserInfo(userId2, userEmail2, pwHash, System.currentTimeMillis());
+            storage.signUp(info);
+            storage.signUp(info2);
+            storage.startTransaction(conn -> {
+                try {
+                    storage.updateUsersEmail_Transaction(conn, userId, userEmail2);
+                    throw new StorageTransactionLogicException(new Exception("This should throw"));
+                } catch (DuplicateEmailException ex) {
+                    // expected
+                }
+                return true;
+            });
+
+            storage.startTransaction(conn -> {
+                try {
+                    storage.updateUsersEmail_Transaction(conn, userId, userEmail3);
+                } catch (DuplicateEmailException ex) {
+                    throw new StorageQueryException(ex);
+                }
+                return true;
+            });
+
+            assertEquals(storage.getUsersCount(new RECIPE_ID[] { RECIPE_ID.EMAIL_PASSWORD }), 2);
+
+            process.kill();
+            assertNotNull(process.checkOrWaitForEvent(ProcessState.PROCESS_STATE.STOPPED));
+        }
+    }
+
+    @Test
+    public void updateIsEmailVerified_TransactionExceptions()
+            throws InterruptedException, StorageQueryException, NoSuchAlgorithmException, InvalidKeyException,
+            SignatureException, InvalidAlgorithmParameterException, NoSuchPaddingException, BadPaddingException,
+            UnsupportedEncodingException, InvalidKeySpecException, IllegalBlockSizeException,
+            StorageTransactionLogicException, DuplicateUserIdException, DuplicateEmailException {
+        {
+            String[] args = { "../" };
+            TestingProcessManager.TestingProcess process = TestingProcessManager.start(args);
+            assertNotNull(process.checkOrWaitForEvent(ProcessState.PROCESS_STATE.STARTED));
+
+            var storage = StorageLayer.getEmailVerificationStorage(process.getProcess());
+
+            String userId = "userId";
+            String userEmail = "useremail@asdf.fdas";
+
+            storage.startTransaction(conn -> {
+                storage.updateIsEmailVerified_Transaction(conn, userId, userEmail, true);
+                // The insert in this call throws, but it's swallowed in the method
+                storage.updateIsEmailVerified_Transaction(conn, userId, userEmail, true);
+                return true;
+            });
+
+            storage.startTransaction(conn -> {
+                try {
+                    // This call should throw, and the method shouldn't swallow it
+                    storage.updateIsEmailVerified_Transaction(conn, null, userEmail, true);
+                    throw new StorageTransactionLogicException(new Exception("This should throw"));
+                } catch (StorageQueryException ex) {
+                    // expected
+                }
+                return true;
+            });
+
+            storage.startTransaction(conn -> {
+                storage.updateIsEmailVerified_Transaction(conn, userId, userEmail, false);
+                return true;
+            });
+
+            // storage.startTransaction(conn -> {
+            // try {
+            // storage.updateIsEmailVerified_Transaction(conn, userId, userEmail2, true);
+            // } catch (StorageQueryException ex) {
+            // throw new StorageQueryException(ex);
+            // }
+            // return true;
+            // });
+
+            process.kill();
+            assertNotNull(process.checkOrWaitForEvent(ProcessState.PROCESS_STATE.STOPPED));
+        }
+    }
+
+    @Test
+    public void addPasswordResetTokenExceptions() throws InterruptedException, StorageQueryException,
+            NoSuchAlgorithmException, InvalidKeyException, SignatureException, InvalidAlgorithmParameterException,
+            NoSuchPaddingException, BadPaddingException, UnsupportedEncodingException, InvalidKeySpecException,
+            IllegalBlockSizeException, StorageTransactionLogicException, DuplicatePasswordResetTokenException,
+            UnknownUserIdException, DuplicateUserIdException, DuplicateEmailException {
+        {
+            String[] args = { "../" };
+            TestingProcessManager.TestingProcess process = TestingProcessManager.start(args);
+            assertNotNull(process.checkOrWaitForEvent(ProcessState.PROCESS_STATE.STARTED));
+
+            var storage = StorageLayer.getEmailPasswordStorage(process.getProcess());
+
+            String userId = "userId";
+            String tokenHash = "fakehash";
+            String pwHash = "fakehash";
+            String userEmail = "useremail@asdf.fdas";
+
+            var userInfo = new UserInfo(userId, userEmail, pwHash, System.currentTimeMillis());
+            var info = new PasswordResetTokenInfo(userId, tokenHash, System.currentTimeMillis() + 10000);
+            try {
+                storage.addPasswordResetToken(info);
+            } catch (UnknownUserIdException ex) {
+                storage.signUp(userInfo);
+            }
+            storage.addPasswordResetToken(info);
+            try {
+                storage.addPasswordResetToken(info);
+            } catch (DuplicatePasswordResetTokenException ex) {
+                // expected
+            }
+
+            process.kill();
+            assertNotNull(process.checkOrWaitForEvent(ProcessState.PROCESS_STATE.STOPPED));
+        }
+    }
+
+    @Test
+    public void addEmailVerificationTokenExceptions() throws InterruptedException, StorageQueryException,
+            NoSuchAlgorithmException, InvalidKeyException, SignatureException, InvalidAlgorithmParameterException,
+            NoSuchPaddingException, BadPaddingException, UnsupportedEncodingException, InvalidKeySpecException,
+            IllegalBlockSizeException, StorageTransactionLogicException, DuplicateEmailVerificationTokenException {
+        {
+            String[] args = { "../" };
+            TestingProcessManager.TestingProcess process = TestingProcessManager.start(args);
+            assertNotNull(process.checkOrWaitForEvent(ProcessState.PROCESS_STATE.STARTED));
+
+            var storage = StorageLayer.getEmailVerificationStorage(process.getProcess());
+
+            String userId = "userId";
+            String tokenHash = "fakehash";
+            String userEmail = "useremail@asdf.fdas";
+
+            var info = new EmailVerificationTokenInfo(userId, tokenHash, System.currentTimeMillis() + 10000, userEmail);
+            storage.addEmailVerificationToken(info);
+            try {
+                storage.addEmailVerificationToken(info);
+            } catch (DuplicateEmailVerificationTokenException ex) {
+                // expected
+            }
+
+            process.kill();
+            assertNotNull(process.checkOrWaitForEvent(ProcessState.PROCESS_STATE.STOPPED));
+        }
+    }
+
+    @Test
+    public void verifyEmailExceptions() throws InterruptedException, StorageQueryException, NoSuchAlgorithmException,
+            InvalidKeyException, SignatureException, InvalidAlgorithmParameterException, NoSuchPaddingException,
+            BadPaddingException, UnsupportedEncodingException, InvalidKeySpecException, IllegalBlockSizeException,
+            StorageTransactionLogicException, DuplicateUserIdException, DuplicateEmailException {
+        {
+            String[] args = { "../" };
+            TestingProcessManager.TestingProcess process = TestingProcessManager.start(args);
+            assertNotNull(process.checkOrWaitForEvent(ProcessState.PROCESS_STATE.STARTED));
+
+            var storage = StorageLayer.getEmailPasswordStorage(process.getProcess());
+
+            String userId = "userId";
+            String userId2 = "userId2";
+            String pwHash = "fakehash";
+            String userEmail = "useremail@asdf.fdas";
+
+            var info = new UserInfo(userId, userEmail, pwHash, System.currentTimeMillis());
+            storage.signUp(info);
+            try {
+                storage.signUp(info);
+            } catch (DuplicateUserIdException ex) {
+                // expected
+            }
+            var info2 = new UserInfo(userId2, userEmail, pwHash, System.currentTimeMillis());
+
+            try {
+                storage.signUp(info2);
+            } catch (DuplicateEmailException ex) {
+                // expected
+            }
+
+            assertEquals(storage.getUsersCount(new RECIPE_ID[] { RECIPE_ID.EMAIL_PASSWORD }), 1);
+
+            process.kill();
+            assertNotNull(process.checkOrWaitForEvent(ProcessState.PROCESS_STATE.STOPPED));
+        }
+    }
+
+    @Test
+    public void setJWTSigningKey_TransactionExceptions() throws InterruptedException, StorageQueryException,
+            NoSuchAlgorithmException, InvalidKeyException, SignatureException, InvalidAlgorithmParameterException,
+            NoSuchPaddingException, BadPaddingException, UnsupportedEncodingException, InvalidKeySpecException,
+            IllegalBlockSizeException, StorageTransactionLogicException {
+        {
+            String[] args = { "../" };
+            TestingProcessManager.TestingProcess process = TestingProcessManager.start(args);
+            assertNotNull(process.checkOrWaitForEvent(ProcessState.PROCESS_STATE.STARTED));
+
+            var storage = (JWTRecipeSQLStorage) StorageLayer.getJWTRecipeStorage(process.getProcess());
+
+            String keyId = "testkeyId";
+            String algorithm = "testalgo";
+            String keyString = "fakeKey";
+
+            // String keyId, long createdAtTime, String algorithm, String keyString
+            var info = new JWTSymmetricSigningKeyInfo(keyId, System.currentTimeMillis(), algorithm, keyString);
+            storage.startTransaction(con -> {
+                try {
+                    storage.setJWTSigningKey_Transaction(con, info);
+                } catch (DuplicateKeyIdException e) {
+                    throw new StorageTransactionLogicException(e);
+                }
+
+                try {
+                    storage.setJWTSigningKey_Transaction(con, info);
+                    throw new StorageTransactionLogicException(new Exception("This should throw"));
+                } catch (DuplicateKeyIdException e) {
+                    // expected
+                }
+
+                return true;
+            });
+
+            process.kill();
+            assertNotNull(process.checkOrWaitForEvent(ProcessState.PROCESS_STATE.STOPPED));
+        }
+    }
+
+}


### PR DESCRIPTION
## Summary of change
Made the error parsing more robust by:
- Explicitly naming our constraints (to the same values as default for PostgreSQL)
- Using PSQLException to do the parsing and checking for the named constraints

## Related issues
- #20 

## Test Plan
Added extra unit tests

## Documentation changes
I'll update the Postgres table creation docs

## Checklist for important updates
- [x] Changelog has been updated
- [x] `pluginInterfaceSupported.json` file has been updated (if needed)
- [x] Changes to the version if needed
   - In `build.gradle`
- [x] Had installed and ran the pre-commit hook
- [x] If there are new dependencies that have been added in `build.gradle`, please make sure to add them in `implementationDependencies.json`.
- [x] Issue this PR against the latest non released version branch.
   - To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
   - If no such branch exists, then create one from the latest released branch.
