### PR TITLE
writes errors to stderr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixes
+
+- Run as container, errors are merged into stdout (instead of going to stderr)
+
 ## [1.13.0] - 2021-12-24
 
 - added passwordless support

--- a/src/main/java/io/supertokens/storage/postgresql/ConnectionPool.java
+++ b/src/main/java/io/supertokens/storage/postgresql/ConnectionPool.java
@@ -135,7 +135,7 @@ public class ConnectionPool extends ResourceDistributor.SingletonResource {
                         }
                         if (!longMessagePrinted) {
                             longMessagePrinted = true;
-                            Logging.info(start, errorMessage);
+                            Logging.error(start, errorMessage, true);
                         }
                         double minsRemaining = (maxTryTime - System.currentTimeMillis()) / (1000.0 * 60);
                         NumberFormat formatter = new DecimalFormat("#0.0");

--- a/src/main/java/io/supertokens/storage/postgresql/output/Logging.java
+++ b/src/main/java/io/supertokens/storage/postgresql/output/Logging.java
@@ -165,6 +165,9 @@ public class Logging extends ResourceDistributor.SingletonResource {
         logConsoleAppender.setEncoder(ple);
         logConsoleAppender.setContext(lc);
         logConsoleAppender.start();
+        if (name.startsWith("io.supertokens.storage.postgresql.Error")) {
+            logConsoleAppender.setTarget("System.err");
+        }
 
         Logger logger = (Logger) LoggerFactory.getLogger(name);
         logger.addAppender(logConsoleAppender);


### PR DESCRIPTION
## Summary of change
When running in a container without $ERROR_LOG_PATH specified, this change will now print errors to stderr (instead of being merged into stdout

## Related issues
- https://github.com/supertokens/supertokens-core/issues/5

## Test Plan
1. Run container with incorrect port: `sudo docker run --network="host" -p 3567:3567 -e POSTGRESQL_HOST="127.0.0.1" -e POSTGRESQL_PORT="5555" supertokens 2> >(while read line; do echo -e "\e[01;31m$line\e[0m" >&2; done)`
2. Confirm error in red
![image](https://user-images.githubusercontent.com/603829/150681656-0bd99b94-cfef-446e-851c-6046745f0ead.png)

## Documentation changes
None

## Checklist for important updates
- [X] Changelog has been updated
- [ ] `pluginInterfaceSupported.json` file has been updated (if needed)
- [ ] Changes to the version if needed
   - In `build.gradle`
- [X] Had installed and ran the pre-commit hook
- [ ] If there are new dependencies that have been added in `build.gradle`, please make sure to add them in `implementationDependencies.json`.
- [ ] Issue this PR against the latest non released version branch.
   - To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
   - If no such branch exists, then create one from the latest released branch.

## Remaining TODOs for this PR
None