### PR TITLE
chore: drop default value after migration in the changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,14 +15,20 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Migration
 
 - If using `access_token_signing_key_dynamic` false in the core:
-  - `ALTER TABLE session_info ADD COLUMN use_static_key BOOLEAN NOT NULL DEFAULT(true);`
+  - ```sql
+    ALTER TABLE session_info ADD COLUMN use_static_key BOOLEAN NOT NULL DEFAULT(true);
+    ALTER TABLE session_info ALTER COLUMN use_static_key DROP DEFAULT;
+    ```
   - ```sql
     INSERT INTO jwt_signing_keys(key_id, key_string, algorithm, created_at)
       select CONCAT('s-', created_at_time) as key_id, value as key_string, 'RS256' as algorithm, created_at_time as created_at
       from session_access_token_signing_keys;
     ```
 - If using `access_token_signing_key_dynamic` true (or not set) in the core:
-  - `ALTER TABLE session_info ADD COLUMN use_static_key BOOLEAN NOT NULL DEFAULT(false);`
+  - ```sql
+    ALTER TABLE session_info ADD COLUMN use_static_key BOOLEAN NOT NULL DEFAULT(false);
+    ALTER TABLE session_info ALTER COLUMN use_static_key DROP DEFAULT;
+    ```
 
 ## [2.4.0] - 2023-03-30
 


### PR DESCRIPTION
## Summary of change

chore: drop default value after migration in the changelog

## Related issues

- 

## Test Plan

N/A, updated only the changelog

## Documentation changes

N/A, updated only the changelog

## Checklist for important updates
- [x] Changelog has been updated
- [x] `pluginInterfaceSupported.json` file has been updated (if needed)
- [x] Changes to the version if needed
   - In `build.gradle`
- [x] Had installed and ran the pre-commit hook
- [x] If there are new dependencies that have been added in `build.gradle`, please make sure to add them in `implementationDependencies.json`.
- [x] Issue this PR against the latest non released version branch.
   - To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
   - If no such branch exists, then create one from the latest released branch.
