### PR TITLE
Fix: add constraint on client name

### DIFF
--- a/src/main/java/io/supertokens/storage/postgresql/Start.java
+++ b/src/main/java/io/supertokens/storage/postgresql/Start.java
@@ -2905,7 +2905,7 @@ public class Start
 
     @Override
     public void createOAuth2Client_Transaction(AppIdentifier appIdentifier, TransactionConnection con, OAuth2Client oAuth2Client)
-            throws StorageQueryException, DuplicateOAuth2ClientSecretHash, DuplicateOAuth2ClientIdException, TenantOrAppNotFoundException {
+            throws StorageQueryException, DuplicateOAuth2ClientSecretHash, DuplicateOAuth2ClientIdException, DuplicateOAuth2ClientNameException, TenantOrAppNotFoundException {
 
         Connection sqlCon = (Connection) con.getConnection();
 
@@ -2916,9 +2916,14 @@ public class Start
                 ServerErrorMessage serverMessage = ((PSQLException) e).getServerErrorMessage();
                 if (isPrimaryKeyError(serverMessage, Config.getConfig(this).getOAuth2ClientTable())) {
                     throw new DuplicateOAuth2ClientIdException();
-                } else if(isUniqueConstraintError(serverMessage, Config.getConfig(this).getOAuth2ClientTable(), "client_secret_hash") ){
+                }
+                if (isUniqueConstraintError(serverMessage, Config.getConfig(this).getOAuth2ClientTable(), "name")) {
+                    throw new DuplicateOAuth2ClientNameException();
+                }
+                if (isUniqueConstraintError(serverMessage, Config.getConfig(this).getOAuth2ClientTable(), "client_secret_hash")){
                     throw new DuplicateOAuth2ClientSecretHash();
-                } else if(isForeignKeyConstraintError(serverMessage, Config.getConfig(this).getOAuth2ClientTable(), "app_id")) {
+                }
+                if (isForeignKeyConstraintError(serverMessage, Config.getConfig(this).getOAuth2ClientTable(), "app_id")) {
                     throw new TenantOrAppNotFoundException(appIdentifier);
                 }
             }

--- a/src/main/java/io/supertokens/storage/postgresql/queries/OAuth2Queries.java
+++ b/src/main/java/io/supertokens/storage/postgresql/queries/OAuth2Queries.java
@@ -56,6 +56,8 @@ public class OAuth2Queries {
                 + "updated_at_ms BIGINT NOT NULL,"
                 + "CONSTRAINT " + Utils.getConstraintName(schema, oAuth2ClientTable, null, "pkey")
                 + " PRIMARY KEY (app_id, client_id),"
+                + "CONSTRAINT " + Utils.getConstraintName(schema, oAuth2ClientTable, "name", "key")
+                + " UNIQUE (app_id, name),"
                 + "CONSTRAINT " + Utils.getConstraintName(schema, oAuth2ClientTable, "app_id", "fkey")
                 + " FOREIGN KEY(app_id) REFERENCES " + getConfig(start).getAppsTable() + "(app_id) ON DELETE CASCADE);";
         // @formatter:on


### PR DESCRIPTION
## Summary of change
Added new unique constraint on name, app_id columns of oauth2_client table
## Related issues
- https://github.com/supertokens/supertokens-core/issues/582

## Test Plan
(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!)

## Documentation changes
(If relevant, please create a PR in our [docs repo](https://github.com/supertokens/docs), or create a checklist here highlighting the necessary changes)

## Checklist for important updates
- [ ] Changelog has been updated
- [ ] `pluginInterfaceSupported.json` file has been updated (if needed)
- [ ] Changes to the version if needed
   - In `build.gradle`
- [ ] Had installed and ran the pre-commit hook
- [ ] If there are new dependencies that have been added in `build.gradle`, please make sure to add them in `implementationDependencies.json`.
- [ ] Issue this PR against the latest non released version branch.
   - To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
   - If no such branch exists, then create one from the latest released branch.