### PR TITLE
fix: add primary_user_id index to app_id_to_user_id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [5.0.4] - 2023-11-23
+
+- Adds `app_id_to_user_id_primary_user_id_index` index on `app_id_to_user_id` table
+
+### Migration
+
+Run the following sql script:
+
+```sql
+CREATE INDEX IF NOT EXISTS app_id_to_user_id_primary_user_id_index ON app_id_to_user_id (primary_or_recipe_user_id, app_id);
+```
+
 ## [5.0.3] - 2023-11-10
 
 - Fixes issue with email verification with user id mapping

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ plugins {
     id 'java-library'
 }
 
-version = "5.0.3"
+version = "5.0.4"
 
 repositories {
     mavenCentral()

--- a/src/main/java/io/supertokens/storage/postgresql/queries/GeneralQueries.java
+++ b/src/main/java/io/supertokens/storage/postgresql/queries/GeneralQueries.java
@@ -231,6 +231,11 @@ public class GeneralQueries {
                 + Config.getConfig(start).getAppIdToUserIdTable() + "(app_id);";
     }
 
+    static String getQueryToCreatePrimaryUserIdIndexForAppIdToUserIdTable(Start start) {
+        return "CREATE INDEX IF NOT EXISTS app_id_to_user_id_primary_user_id_index ON "
+                + Config.getConfig(start).getAppIdToUserIdTable() + "(primary_or_recipe_user_id, app_id);";
+    }
+
     public static void createTablesIfNotExists(Start start) throws SQLException, StorageQueryException {
         int numberOfRetries = 0;
         boolean retry = true;
@@ -264,6 +269,7 @@ public class GeneralQueries {
 
                     // index
                     update(start, getQueryToCreateAppIdIndexForAppIdToUserIdTable(start), NO_OP_SETTER);
+                    update(start, getQueryToCreatePrimaryUserIdIndexForAppIdToUserIdTable(start), NO_OP_SETTER);
                 }
 
                 if (!doesTableExists(start, Config.getConfig(start).getUsersTable())) {


### PR DESCRIPTION
## Summary of change

Adds an index for foreign key in app_id_to_user_id table.

## Related issues
- https://github.com/supertokens/supertokens-core/issues/887

## Test Plan
(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!)

## Documentation changes
(If relevant, please create a PR in our [docs repo](https://github.com/supertokens/docs), or create a checklist here highlighting the necessary changes)

## Checklist for important updates
- [ ] Changelog has been updated
- [ ] `pluginInterfaceSupported.json` file has been updated (if needed)
- [ ] Changes to the version if needed
   - In `build.gradle`
- [ ] Had installed and ran the pre-commit hook
- [ ] If there are new dependencies that have been added in `build.gradle`, please make sure to add them in `implementationDependencies.json`.
- [ ] Issue this PR against the latest non released version branch.
   - To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
   - If no such branch exists, then create one from the latest released branch.

## Remaining TODOs for this PR
- [ ] Item1
- [ ] Item2