### PR TITLE
feat: Add support to update the signing key type of a session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Replace `TotpNotEnabledError` with `UnknownUserIdTotpError`.
 - Support for MFA recipe
+- Adds a new `useStaticKey` param to `updateSessionInfo_Transaction`
+  - This enables smooth switching between `useDynamicAccessTokenSigningKey` settings by allowing refresh calls to
+    change the signing key type of a session
 
 ## [5.0.6] - 2023-12-05
 

--- a/src/main/java/io/supertokens/storage/postgresql/Start.java
+++ b/src/main/java/io/supertokens/storage/postgresql/Start.java
@@ -644,11 +644,11 @@ public class Start
     @Override
     public void updateSessionInfo_Transaction(TenantIdentifier tenantIdentifier, TransactionConnection con,
                                               String sessionHandle, String refreshTokenHash2,
-                                              long expiry) throws StorageQueryException {
+                                              long expiry, boolean useStaticKey) throws StorageQueryException {
         Connection sqlCon = (Connection) con.getConnection();
         try {
             SessionQueries.updateSessionInfo_Transaction(this, sqlCon, tenantIdentifier, sessionHandle,
-                    refreshTokenHash2, expiry);
+                    refreshTokenHash2, expiry, useStaticKey);
         } catch (SQLException e) {
             throw new StorageQueryException(e);
         }

--- a/src/main/java/io/supertokens/storage/postgresql/queries/SessionQueries.java
+++ b/src/main/java/io/supertokens/storage/postgresql/queries/SessionQueries.java
@@ -166,18 +166,19 @@ public class SessionQueries {
 
     public static void updateSessionInfo_Transaction(Start start, Connection con, TenantIdentifier tenantIdentifier,
                                                      String sessionHandle,
-                                                     String refreshTokenHash2, long expiry)
+                                                     String refreshTokenHash2, long expiry, boolean useStaticKey)
             throws SQLException, StorageQueryException {
         String QUERY = "UPDATE " + getConfig(start).getSessionInfoTable()
-                + " SET refresh_token_hash_2 = ?, expires_at = ?"
+                + " SET refresh_token_hash_2 = ?, expires_at = ?, use_static_key = ?"
                 + " WHERE app_id = ? AND tenant_id = ? AND session_handle = ?";
 
         update(con, QUERY, pst -> {
             pst.setString(1, refreshTokenHash2);
             pst.setLong(2, expiry);
-            pst.setString(3, tenantIdentifier.getAppId());
-            pst.setString(4, tenantIdentifier.getTenantId());
-            pst.setString(5, sessionHandle);
+            pst.setBoolean(3, useStaticKey);
+            pst.setString(4, tenantIdentifier.getAppId());
+            pst.setString(5, tenantIdentifier.getTenantId());
+            pst.setString(6, sessionHandle);
         });
     }
 


### PR DESCRIPTION
## Summary of change

- Adds a new `useStaticKey` param to `updateSessionInfo_Transaction`
  - This enables smooth switching between `useDynamicAccessTokenSigningKey` settings by allowing refresh calls to
    change the signing key type of a session

## Related issues

- core: https://github.com/supertokens/supertokens-core/pull/909
- plugin-interface: https://github.com/supertokens/supertokens-plugin-interface/pull/136
- postgresql-plugin: https://github.com/supertokens/supertokens-postgresql-plugin/pull/180
- mysql-plugin: https://github.com/supertokens/supertokens-mysql-plugin/pull/88
- mongodb-plugin: https://github.com/supertokens/supertokens-mongodb-plugin/pull/31
- node: https://github.com/supertokens/supertokens-node/pull/782

## Test Plan
Done in core PR

## Documentation changes
Done in core PR

## Checklist for important updates
- [x] Changelog has been updated
- [x] `pluginInterfaceSupported.json` file has been updated (if needed)
- [x] Changes to the version if needed
   - In `build.gradle`
- [x] Had installed and ran the pre-commit hook
- [x] If there are new dependencies that have been added in `build.gradle`, please make sure to add them in `implementationDependencies.json`.
- [x] Issue this PR against the latest non released version branch.
   - To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
   - If no such branch exists, then create one from the latest released branch.
