### PR TITLE
fix: add index for session_info on user_id, app_id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,18 +7,11 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
--  Adds indexing for `session_info` table on `user_id, app_id` columns
-
-### Migration
-
-```sql
-CREATE INDEX IF NOT EXISTS session_info_user_id_app_id_index ON session_info (user_id, app_id);
-```
-
 ## [7.3.0] 
 
 - Adds tables and queries for Bulk Import
 - Optimize getUserIdMappingWithEitherSuperTokensUserIdOrExternalUserId query
+- Adds indexing for `session_info` table on `user_id, app_id` columns
 
 ### Migration
 
@@ -42,6 +35,8 @@ CREATE INDEX IF NOT EXISTS bulk_import_users_pagination_index1 ON bulk_import_us
  id DESC);
  
 CREATE INDEX IF NOT EXISTS bulk_import_users_pagination_index2 ON bulk_import_users (app_id, created_at DESC, id DESC);
+
+CREATE INDEX IF NOT EXISTS session_info_user_id_app_id_index ON session_info (user_id, app_id);
 ```
 
 ## [7.2.0] - 2024-10-03

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+-  Adds indexing for `session_info` table on `user_id, app_id` columns
+
+### Migration
+
+```sql
+CREATE INDEX IF NOT EXISTS session_info_user_id_app_id_index ON session_info (user_id, app_id);
+```
+
 ## [7.3.0] 
 
 - Adds tables and queries for Bulk Import

--- a/src/main/java/io/supertokens/storage/postgresql/queries/GeneralQueries.java
+++ b/src/main/java/io/supertokens/storage/postgresql/queries/GeneralQueries.java
@@ -335,6 +335,7 @@ public class GeneralQueries {
 
                     // index
                     update(con, getQueryToCreateSessionExpiryIndex(start), NO_OP_SETTER);
+                    update(con, getQueryToCreateSessionAppIdUserIdIndex(start), NO_OP_SETTER);
                     update(con, getQueryToCreateTenantIdIndexForSessionInfoTable(start), NO_OP_SETTER);
                 }
 

--- a/src/main/java/io/supertokens/storage/postgresql/queries/SessionQueries.java
+++ b/src/main/java/io/supertokens/storage/postgresql/queries/SessionQueries.java
@@ -100,6 +100,11 @@ public class SessionQueries {
                 + Config.getConfig(start).getSessionInfoTable() + "(expires_at);";
     }
 
+    static String getQueryToCreateSessionAppIdUserIdIndex(Start start) {
+        return "CREATE INDEX IF NOT EXISTS session_info_user_id_app_id_index ON "
+                + Config.getConfig(start).getSessionInfoTable() + "(user_id, app_id);";
+    }
+
     public static void createNewSession(Start start, TenantIdentifier tenantIdentifier, String sessionHandle,
                                         String userId, String refreshTokenHash2,
                                         JsonObject userDataInDatabase, long expiry, JsonObject userDataInJWT,


### PR DESCRIPTION
## Summary of change

The lack of index on `session_info`'s `(app_id, user_id)` was causing performance issues at one of the users, so here it goes.


## Related issues

- Link to issue1 here
- Link to issue1 here

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your
changes work. Bonus points for screenshots and videos!)

## Documentation changes

(If relevant, please create a PR in our [docs repo](https://github.com/supertokens/docs), or create a checklist here
highlighting the necessary changes)

## Checklist for important updates

- [ ] Changelog has been updated
- [ ] `pluginInterfaceSupported.json` file has been updated (if needed)
- [ ] Changes to the version if needed
    - In `build.gradle`
- [ ] Had installed and ran the pre-commit hook
- [ ] If there are new dependencies that have been added in `build.gradle`, please make sure to add them
  in `implementationDependencies.json`.
- [ ] Issue this PR against the latest non released version branch.
    - To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the
      latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    - If no such branch exists, then create one from the latest released branch.
- [ ] When adding new recipes, ensure that its performance is being measured in the `OneMillionUsersTest`

## Remaining TODOs for this PR

- [ ] Item1
- [ ] Item2