### PR TITLE
fix: add tcpKeepAlive to connectionPool config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [8.1.3]
+
+- Adds tcpKeepAlive to the connection pool config
+
 ## [8.1.2]
 
 - Adds user_id index to the user roles table

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ plugins {
     id 'java-library'
 }
 
-version = "8.1.2"
+version = "8.1.3"
 
 repositories {
     mavenCentral()

--- a/src/main/java/io/supertokens/storage/postgresql/ConnectionPool.java
+++ b/src/main/java/io/supertokens/storage/postgresql/ConnectionPool.java
@@ -91,6 +91,7 @@ public class ConnectionPool extends ResourceDistributor.SingletonResource {
         config.addDataSourceProperty("cachePrepStmts", "true");
         config.addDataSourceProperty("prepStmtCacheSize", "250");
         config.addDataSourceProperty("prepStmtCacheSqlLimit", "2048");
+        config.addDataSourceProperty("tcpKeepAlive", "true");
         // TODO: set maxLifetimeValue to lesser than 10 mins so that the following error doesnt happen:
         // io.supertokens.storage.postgresql.HikariLoggingAppender.doAppend(HikariLoggingAppender.java:117) |
         // SuperTokens


### PR DESCRIPTION
## Summary of change

add tcpKeepAlive to connectionPool config

## Related issues

- Link to issue1 here
- Link to issue1 here

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your
changes work. Bonus points for screenshots and videos!)

## Documentation changes

(If relevant, please create a PR in our [docs repo](https://github.com/supertokens/docs), or create a checklist here
highlighting the necessary changes)

## Checklist for important updates

- [ ] Changelog has been updated
- [ ] `pluginInterfaceSupported.json` file has been updated (if needed)
- [ ] Changes to the version if needed
    - In `build.gradle`
- [ ] Had installed and ran the pre-commit hook
- [ ] If there are new dependencies that have been added in `build.gradle`, please make sure to add them
  in `implementationDependencies.json`.
- [ ] Issue this PR against the latest non released version branch.
    - To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the
      latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    - If no such branch exists, then create one from the latest released branch.
- [ ] When adding new recipes, ensure that its performance is being measured in the `OneMillionUsersTest`

## Remaining TODOs for this PR

- [ ] Item1
- [ ] Item2