### PR TITLE
feat(docker): add otel_connection_uri to entrypoint

### DIFF
--- a/.github/helpers/docker/docker-entrypoint.sh
+++ b/.github/helpers/docker/docker-entrypoint.sh
@@ -291,6 +291,12 @@ then
         echo "postgresql_connection_uri: $POSTGRESQL_CONNECTION_URI" >> $CONFIG_FILE
     fi
 
+    # check if the otel collector connection uri is passed
+    if [ ! -z $OTEL_COLLECTOR_CONNECTION_URI ]
+    then
+        echo "otel_collector_connection_uri: $OTEL_COLLECTOR_CONNECTION_URI" >> $CONFIG_FILE
+    fi
+
     # THE CONFIGS BELOW ARE DEPRECATED----------------
 
     # check if postgresql key value table name is passed


### PR DESCRIPTION
## Summary of change

SuperToken Core has the feature to configure the otel collector connection uri but this is not configurable through the docker image. 
There is no change to actual postgres plugin. Just the docker entrypoint.