### PR TITLE
feat!: Add dormant activity_log table (creation only)

### DIFF
--- a/src/main/java/io/supertokens/storage/postgresql/config/PostgreSQLConfig.java
+++ b/src/main/java/io/supertokens/storage/postgresql/config/PostgreSQLConfig.java
@@ -390,6 +390,10 @@ public class PostgreSQLConfig {
         return addSchemaAndPrefixToTableName("user_last_active");
     }
 
+    public String getActivityLogTable() {
+        return addSchemaAndPrefixToTableName("activity_log");
+    }
+
     public String getAccessTokenSigningKeysTable() {
         return addSchemaAndPrefixToTableName("session_access_token_signing_keys");
     }

--- a/src/main/java/io/supertokens/storage/postgresql/queries/ActivityLogQueries.java
+++ b/src/main/java/io/supertokens/storage/postgresql/queries/ActivityLogQueries.java
@@ -1,0 +1,68 @@
+/*
+ *    Copyright (c) 2026, VRAI Labs and/or its affiliates. All rights reserved.
+ *
+ *    This software is licensed under the Apache License, Version 2.0 (the
+ *    "License") as published by the Apache Software Foundation.
+ *
+ *    You may not use this file except in compliance with the License. You may
+ *    obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *    License for the specific language governing permissions and limitations
+ *    under the License.
+ */
+
+package io.supertokens.storage.postgresql.queries;
+
+import io.supertokens.storage.postgresql.Start;
+import io.supertokens.storage.postgresql.config.Config;
+
+/**
+ * Append-only audit/activity log.
+ *
+ * Shipped dormant: the table is created so that enabling the writer later does not require a
+ * schema migration. It is range-partitioned by {@code created_at} (monthly partitions are
+ * created by a separate job once the writer is enabled; a DEFAULT partition catches anything
+ * in the meantime). No primary key (the identity sequence makes {@code id} unique by
+ * construction and the log is never upserted or looked up by id) and no foreign key.
+ *
+ * The only index provisioned now is a BRIN on {@code created_at}: nearly free on writes for
+ * append-only, physically-ordered data, and enough to prune time-range scans. The
+ * {@code recipe_user_id} btree needed for per-user reads is deliberately deferred to the
+ * user-facing release. Requires PostgreSQL 11+ (declarative partitioning, identity columns,
+ * partitioned BRIN index).
+ *
+ * See PLAN-ACTIVITY-LOG-AND-MAU-ROLLUP.md for the full design.
+ */
+public class ActivityLogQueries {
+
+    static String getQueryToCreateActivityLogTable(Start start) {
+        String tableName = Config.getConfig(start).getActivityLogTable();
+        return "CREATE TABLE IF NOT EXISTS " + tableName + " ("
+                + "id BIGINT GENERATED ALWAYS AS IDENTITY,"
+                + "app_id VARCHAR(64) NOT NULL DEFAULT 'public',"
+                + "tenant_id VARCHAR(64) NOT NULL DEFAULT 'public',"
+                + "recipe_user_id VARCHAR(128),"
+                + "primary_or_recipe_user_id VARCHAR(128),"
+                + "event_type VARCHAR(64) NOT NULL,"
+                + "status VARCHAR(128),"
+                + "auth_principal VARCHAR(256),"
+                + "identifier VARCHAR(256),"
+                + "created_at BIGINT NOT NULL,"
+                + "payload JSONB"
+                + ") PARTITION BY RANGE (created_at);";
+    }
+
+    static String getQueryToCreateActivityLogDefaultPartition(Start start) {
+        String tableName = Config.getConfig(start).getActivityLogTable();
+        return "CREATE TABLE IF NOT EXISTS " + tableName + "_default PARTITION OF "
+                + tableName + " DEFAULT;";
+    }
+
+    static String getQueryToCreateCreatedAtBrinIndex(Start start) {
+        return "CREATE INDEX IF NOT EXISTS activity_log_created_at_brin ON "
+                + Config.getConfig(start).getActivityLogTable() + " USING brin (created_at);";
+    }
+}

--- a/src/main/java/io/supertokens/storage/postgresql/queries/GeneralQueries.java
+++ b/src/main/java/io/supertokens/storage/postgresql/queries/GeneralQueries.java
@@ -381,6 +381,15 @@ public class GeneralQueries {
                             NO_OP_SETTER);
                 }
 
+                if (!doesTableExists(start, con, Config.getConfig(start).getActivityLogTable())) {
+                    getInstance(start).addState(CREATING_NEW_TABLE, null);
+                    update(con, ActivityLogQueries.getQueryToCreateActivityLogTable(start), NO_OP_SETTER);
+                    update(con, ActivityLogQueries.getQueryToCreateActivityLogDefaultPartition(start), NO_OP_SETTER);
+
+                    // index
+                    update(con, ActivityLogQueries.getQueryToCreateCreatedAtBrinIndex(start), NO_OP_SETTER);
+                }
+
                 if (!doesTableExists(start, con, Config.getConfig(start).getAccessTokenSigningKeysTable())) {
                     getInstance(start).addState(CREATING_NEW_TABLE, null);
                     update(con, getQueryToCreateAccessTokenSigningKeysTable(start), NO_OP_SETTER);
@@ -834,6 +843,7 @@ public class GeneralQueries {
             String DROP_QUERY = "DROP TABLE IF EXISTS "
                     + getConfig(start).getAppsTable() + ","
                     + getConfig(start).getUserLastActiveTable() + ","
+                    + getConfig(start).getActivityLogTable() + ","
                     + getConfig(start).getTenantsTable() + ","
                     + getConfig(start).getKeyValueTable() + ","
                     + getConfig(start).getAppIdToUserIdTable() + ","


### PR DESCRIPTION
Append-only, range-partitioned (by created_at) activity_log table, created at boot via createTablesIfNotExists. No PK/FK; one BRIN index on created_at. Shipped dormant (no reads/writes wired) so enabling the audit-log writer later needs no schema migration. Requires PostgreSQL 11+.

## Summary of change

(A few sentences about this PR)

## Related issues

- Link to issue1 here
- Link to issue1 here

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your
changes work. Bonus points for screenshots and videos!)

## Documentation changes

(If relevant, please create a PR in our [docs repo](https://github.com/supertokens/docs), or create a checklist here
highlighting the necessary changes)

## Checklist for important updates

- [ ] Changelog has been updated
- [ ] `pluginInterfaceSupported.json` file has been updated (if needed)
- [ ] Changes to the version if needed
    - In `build.gradle`
- [ ] Had installed and ran the pre-commit hook
- [ ] If there are new dependencies that have been added in `build.gradle`, please make sure to add them
  in `implementationDependencies.json`.
- [ ] Issue this PR against the latest non released version branch.
    - To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the
      latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    - If no such branch exists, then create one from the latest released branch.
- [ ] When adding new recipes, ensure that its performance is being measured in the `OneMillionUsersTest`

## Remaining TODOs for this PR

- [ ] Item1
- [ ] Item2