### PR TITLE
fix: use existence queries for non-auth recipe user probes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+- Fixes `isUserIdBeingUsedInNonAuthRecipe` to use O(1) existence probes (`SELECT 1 ... LIMIT 1`) for sessions,
+  user roles and TOTP devices instead of loading every matching row
+
 ## [9.5.6]
 
 - Adds `SKIP LOCKED` to the backfill batch locking query to improve performance

--- a/src/main/java/io/supertokens/storage/postgresql/Start.java
+++ b/src/main/java/io/supertokens/storage/postgresql/Start.java
@@ -859,11 +859,17 @@ public class Start
             throws StorageQueryException {
         // check if the input userId is being used in nonAuthRecipes.
         if (className.equals(SessionStorage.class.getName())) {
-            String[] sessionHandlesForUser = getAllNonExpiredSessionHandlesForUser(appIdentifier, userId);
-            return sessionHandlesForUser.length > 0;
+            try {
+                return SessionQueries.doesNonExpiredSessionExistForUser(this, appIdentifier, userId);
+            } catch (SQLException e) {
+                throw new StorageQueryException(e);
+            }
         } else if (className.equals(UserRolesStorage.class.getName())) {
-            String[] roles = getRolesForUser(appIdentifier, userId);
-            return roles.length > 0;
+            try {
+                return UserRolesQueries.doesUserHaveAnyRole(this, appIdentifier, userId);
+            } catch (SQLException e) {
+                throw new StorageQueryException(e);
+            }
         } else if (className.equals(UserMetadataStorage.class.getName())) {
             JsonObject userMetadata = getUserMetadata(appIdentifier, userId);
             return userMetadata != null;
@@ -875,8 +881,7 @@ public class Start
             }
         } else if (className.equals(TOTPStorage.class.getName())) {
             try {
-                TOTPDevice[] devices = TOTPQueries.getDevices(this, appIdentifier, userId);
-                return devices.length > 0;
+                return TOTPQueries.doesUserHaveAnyDevice(this, appIdentifier, userId);
             } catch (SQLException e) {
                 throw new StorageQueryException(e);
             }

--- a/src/main/java/io/supertokens/storage/postgresql/Start.java
+++ b/src/main/java/io/supertokens/storage/postgresql/Start.java
@@ -644,15 +644,6 @@ public class Start
         }
     }
 
-    private String[] getAllNonExpiredSessionHandlesForUser(AppIdentifier appIdentifier, String userId)
-            throws StorageQueryException {
-        try {
-            return SessionQueries.getAllNonExpiredSessionHandlesForUser(this, appIdentifier, userId);
-        } catch (SQLException e) {
-            throw new StorageQueryException(e);
-        }
-    }
-
     @Override
     public void deleteAllExpiredSessions() throws StorageQueryException {
         try {
@@ -2715,15 +2706,6 @@ public class Start
             StorageQueryException {
         try {
             return UserRolesQueries.getRolesForUser(this, tenantIdentifier, userId);
-        } catch (SQLException e) {
-            throw new StorageQueryException(e);
-        }
-    }
-
-    private String[] getRolesForUser(AppIdentifier appIdentifier, String userId) throws
-            StorageQueryException {
-        try {
-            return UserRolesQueries.getRolesForUser(this, appIdentifier, userId);
         } catch (SQLException e) {
             throw new StorageQueryException(e);
         }

--- a/src/main/java/io/supertokens/storage/postgresql/queries/SessionQueries.java
+++ b/src/main/java/io/supertokens/storage/postgresql/queries/SessionQueries.java
@@ -355,6 +355,20 @@ public class SessionQueries {
         });
     }
 
+    public static boolean doesNonExpiredSessionExistForUser(Start start, AppIdentifier appIdentifier, String userId)
+            throws SQLException, StorageQueryException {
+        // existence check only: must not load the user's session handles, which can number in the
+        // hundreds of thousands for long-lived / never-revoked sessions.
+        String QUERY = "SELECT 1 FROM " + getConfig(start).getSessionInfoTable()
+                + " WHERE app_id = ? AND user_id = ? AND expires_at >= ? LIMIT 1";
+
+        return execute(start, QUERY, pst -> {
+            pst.setString(1, appIdentifier.getAppId());
+            pst.setString(2, userId);
+            pst.setLong(3, currentTimeMillis());
+        }, ResultSet::next);
+    }
+
     public static String[] getAllNonExpiredSessionHandlesForUser(Start start, AppIdentifier appIdentifier,
                                                                  String userId)
             throws SQLException, StorageQueryException {

--- a/src/main/java/io/supertokens/storage/postgresql/queries/TOTPQueries.java
+++ b/src/main/java/io/supertokens/storage/postgresql/queries/TOTPQueries.java
@@ -271,6 +271,18 @@ public class TOTPQueries {
         });
     }
 
+    public static boolean doesUserHaveAnyDevice(Start start, AppIdentifier appIdentifier, String userId)
+            throws StorageQueryException, SQLException {
+        // existence check only — see doesNonExpiredSessionExistForUser
+        String QUERY = "SELECT 1 FROM " + Config.getConfig(start).getTotpUserDevicesTable()
+                + " WHERE app_id = ? AND user_id = ? LIMIT 1";
+
+        return execute(start, QUERY, pst -> {
+            pst.setString(1, appIdentifier.getAppId());
+            pst.setString(2, userId);
+        }, ResultSet::next);
+    }
+
     public static TOTPDevice[] getDevices(Start start, AppIdentifier appIdentifier, String userId)
             throws StorageQueryException, SQLException {
         String QUERY = "SELECT * FROM " + Config.getConfig(start).getTotpUserDevicesTable()

--- a/src/main/java/io/supertokens/storage/postgresql/queries/UserRolesQueries.java
+++ b/src/main/java/io/supertokens/storage/postgresql/queries/UserRolesQueries.java
@@ -256,6 +256,18 @@ public class UserRolesQueries {
         });
     }
 
+    public static boolean doesUserHaveAnyRole(Start start, AppIdentifier appIdentifier, String userId)
+            throws SQLException, StorageQueryException {
+        // existence check only — see doesNonExpiredSessionExistForUser
+        String QUERY = "SELECT 1 FROM " + getConfig(start).getUserRolesTable()
+                + " WHERE app_id = ? AND user_id = ? LIMIT 1";
+
+        return execute(start, QUERY, pst -> {
+            pst.setString(1, appIdentifier.getAppId());
+            pst.setString(2, userId);
+        }, ResultSet::next);
+    }
+
     public static String[] getRolesForUser(Start start, AppIdentifier appIdentifier, String userId)
             throws SQLException, StorageQueryException {
         String QUERY = "SELECT role FROM " + getConfig(start).getUserRolesTable()

--- a/src/test/java/io/supertokens/storage/postgresql/test/SessionExistenceProbeTest.java
+++ b/src/test/java/io/supertokens/storage/postgresql/test/SessionExistenceProbeTest.java
@@ -1,0 +1,111 @@
+/*
+ *    Copyright (c) 2026, VRAI Labs and/or its affiliates. All rights reserved.
+ *
+ *    This software is licensed under the Apache License, Version 2.0 (the
+ *    "License") as published by the Apache Software Foundation.
+ *
+ *    You may not use this file except in compliance with the License. You may
+ *    obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *    License for the specific language governing permissions and limitations
+ *    under the License.
+ *
+ */
+
+package io.supertokens.storage.postgresql.test;
+
+import com.google.gson.JsonObject;
+import io.supertokens.ProcessState;
+import io.supertokens.pluginInterface.STORAGE_TYPE;
+import io.supertokens.pluginInterface.multitenancy.AppIdentifier;
+import io.supertokens.pluginInterface.session.SessionStorage;
+import io.supertokens.session.Session;
+import io.supertokens.storage.postgresql.Start;
+import io.supertokens.storage.postgresql.config.Config;
+import io.supertokens.storageLayer.StorageLayer;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestRule;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+public class SessionExistenceProbeTest {
+
+    @Rule
+    public TestRule watchman = Utils.getOnFailure();
+
+    @AfterClass
+    public static void afterTesting() {
+        Utils.afterTesting();
+    }
+
+    @Before
+    public void beforeEach() {
+        Utils.reset();
+    }
+
+    /**
+     * isUserIdBeingUsedInNonAuthRecipe uses a SELECT 1 ... LIMIT 1 existence probe for sessions
+     * instead of loading every session handle. This pins its semantics: only non-expired sessions
+     * count as "the user id is in use".
+     */
+    @Test
+    public void sessionProbeCountsOnlyNonExpiredSessions() throws Exception {
+        String[] args = {"../"};
+
+        TestingProcessManager.TestingProcess process = TestingProcessManager.start(args);
+        assertNotNull(process.checkOrWaitForEvent(ProcessState.PROCESS_STATE.STARTED));
+
+        if (StorageLayer.getStorage(process.getProcess()).getType() != STORAGE_TYPE.SQL) {
+            process.kill();
+            assertNotNull(process.checkOrWaitForEvent(ProcessState.PROCESS_STATE.STOPPED));
+            return;
+        }
+
+        Start storage = (Start) StorageLayer.getStorage(process.getProcess());
+        AppIdentifier appIdentifier = new AppIdentifier(null, null);
+        String userId = "session-probe-test-user";
+
+        // no sessions at all -> not in use
+        assertFalse(storage.isUserIdBeingUsedInNonAuthRecipe(appIdentifier, SessionStorage.class.getName(), userId));
+
+        Session.createNewSession(process.getProcess(), userId, new JsonObject(), new JsonObject());
+
+        // live session -> in use
+        assertTrue(storage.isUserIdBeingUsedInNonAuthRecipe(appIdentifier, SessionStorage.class.getName(), userId));
+
+        // expire the session behind the API's back (updateSessionInfo_Transaction and friends
+        // always stamp future expiries, so raw SQL is the only way to backdate expires_at)
+        expireAllSessionsOfUser(storage, userId);
+
+        // only expired sessions left -> not in use
+        assertFalse(storage.isUserIdBeingUsedInNonAuthRecipe(appIdentifier, SessionStorage.class.getName(), userId));
+
+        process.kill();
+        assertNotNull(process.checkOrWaitForEvent(ProcessState.PROCESS_STATE.STOPPED));
+    }
+
+    private void expireAllSessionsOfUser(Start storage, String userId) throws Exception {
+        String query = "UPDATE " + Config.getConfig(storage).getSessionInfoTable()
+                + " SET expires_at = ? WHERE user_id = ?";
+        storage.startTransaction(con -> {
+            Connection sqlCon = (Connection) con.getConnection();
+            try (PreparedStatement pst = sqlCon.prepareStatement(query)) {
+                pst.setLong(1, System.currentTimeMillis() - 1000);
+                pst.setString(2, userId);
+                pst.executeUpdate();
+            }
+            return null;
+        });
+    }
+}


### PR DESCRIPTION
## Problem

`isUserIdBeingUsedInNonAuthRecipe` answers a boolean ("is this userId used by this recipe?") by
loading **all** matching rows and checking `.length > 0`:

- `SessionStorage` -> `getAllNonExpiredSessionHandlesForUser(...)` (`SELECT session_handle ... WHERE app_id = ? AND user_id = ? AND expires_at >= ?`, no LIMIT)
- `UserRolesStorage` -> `getRolesForUser(...).length > 0`
- `TOTPStorage` -> `getDevices(...).length > 0`

The session variant is reachable from `GET /user/id` (`userIdType = ANY`) whenever the userId has no
auth-recipe row: `findNonAuthStoragesWhereUserIdIsUsedOrAssertIfUsed` probes `SessionStorage` first.

Sessions can be created for arbitrary user ids and are not capped per user, so this set can grow
without bound. On a deployment where a client polled `/user/id` for a user id with ~300k non-expired
sessions, each request materialised the full handle list: tens of MB of transient allocation and a
pooled connection held for seconds. With a small per-tenant pool that saturates the pool, so unrelated
requests on the same tenant hit the connection-acquire timeout and fail; the allocation rate also
drove a ~33x increase in young-GC frequency and pushed container CPU to 85-90%.

## Change

Add existence-only queries and use them for the probes:

- `SessionQueries.doesNonExpiredSessionExistForUser` - `SELECT 1 ... LIMIT 1` (served by the existing `session_info_user_id_app_id_index`)
- `UserRolesQueries.doesUserHaveAnyRole` - `SELECT 1 ... LIMIT 1`
- `TOTPQueries.doesUserHaveAnyDevice` - `SELECT 1 ... LIMIT 1`

The existing list-returning methods are untouched (still used by the listing APIs). Behaviour is
identical - cost goes from O(rows) to O(1).

## Testing

- Existing non-auth-recipe suites (user-id mapping, user roles, TOTP) assert booleans, not row lists.
- Manual: with a user id that has a large number of sessions, `GET /user/id?userId=<unknown-id>`
  returns in ~ms instead of seconds, and a concurrent poll no longer exhausts the tenant pool.

Suggested follow-up (not in this PR): `findNonAuthRecipesWhereForUserIdsUsed` (the batch path used by
bulk import) still loads full handle/role lists per user and has the same hazard shape.
