### PR TITLE
fix: keep the database password out of the connection pool id and telemetry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+- Fixes the raw database password being embedded verbatim in the HikariCP connection pool name (which is
+  included in Hikari log lines, exception messages and telemetry exports): the pool id now uses a truncated
+  SHA-256 hash of the password instead. Also masks the password on the OpenTelemetry log appender path.
+
 ## [9.5.6]
 
 - Adds `SKIP LOCKED` to the backfill batch locking query to improve performance

--- a/src/main/java/io/supertokens/storage/postgresql/HikariLoggingAppender.java
+++ b/src/main/java/io/supertokens/storage/postgresql/HikariLoggingAppender.java
@@ -28,6 +28,7 @@ import ch.qos.logback.core.status.Status;
 import io.supertokens.pluginInterface.multitenancy.TenantIdentifier;
 import io.supertokens.pluginInterface.opentelemetry.OtelProvider;
 import io.supertokens.storage.postgresql.output.Logging;
+import io.supertokens.storage.postgresql.utils.Utils;
 
 import java.util.List;
 import java.util.Map;
@@ -149,7 +150,9 @@ public class HikariLoggingAppender implements Appender<ILoggingEvent> {
 
     private void appendToOtel(ILoggingEvent event) {
         if (otelProvider != null) {
-            String logMessage = event.getFormattedMessage();
+            // must mask here too: unlike the file/console appenders (CustomLayout), this path
+            // does not go through Utils.maskDBPassword
+            String logMessage = Utils.maskDBPassword(event.getFormattedMessage());
             String logLevel = event.getLevel().toString();
             otelProvider.createLogEvent(TenantIdentifier.BASE_TENANT, logMessage, logLevel,
                     Map.of("loggerName", event.getLoggerName(),

--- a/src/main/java/io/supertokens/storage/postgresql/config/PostgreSQLConfig.java
+++ b/src/main/java/io/supertokens/storage/postgresql/config/PostgreSQLConfig.java
@@ -33,6 +33,9 @@ import io.supertokens.storage.postgresql.annotations.*;
 
 import java.lang.reflect.Field;
 import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.util.*;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
@@ -863,6 +866,21 @@ public class PostgreSQLConfig {
         return userPoolId.toString();
     }
 
+    private static String hashPassword(String password) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            byte[] hash = digest.digest(password.getBytes(StandardCharsets.UTF_8));
+            StringBuilder hex = new StringBuilder();
+            // 12 hex chars (48 bits) is ample to keep distinct credentials in distinct pools
+            for (int i = 0; i < 6; i++) {
+                hex.append(String.format("%02x", hash[i]));
+            }
+            return hex.toString();
+        } catch (NoSuchAlgorithmException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
     public String getConnectionPoolId() {
         StringBuilder connectionPoolId = new StringBuilder();
         for (Field field : PostgreSQLConfig.class.getDeclaredFields()) {
@@ -873,11 +891,12 @@ public class PostgreSQLConfig {
                     if (fieldValue == null) {
                         continue;
                     }
-                    // To ensure a unique connectionPoolId we include the database password and use the "|db_pass|"
-                    // identifier.
-                    // This facilitates easy removal of the password from logs when necessary.
+                    // The password must contribute to the uniqueness of the connectionPoolId, but must
+                    // never appear in it verbatim: this id becomes the HikariCP pool name, which is
+                    // included in Hikari log lines, exception messages and telemetry exports.
+                    // A hash preserves uniqueness without exposing the secret.
                     if (fieldName.equals("postgresql_password")) {
-                        connectionPoolId.append("|db_pass|" + fieldValue + "|db_pass");
+                        connectionPoolId.append("|db_pass|" + hashPassword(fieldValue) + "|db_pass");
                     } else {
                         connectionPoolId.append("|" + fieldValue);
                     }

--- a/src/test/java/io/supertokens/storage/postgresql/test/ConnectionPoolIdTest.java
+++ b/src/test/java/io/supertokens/storage/postgresql/test/ConnectionPoolIdTest.java
@@ -1,0 +1,73 @@
+/*
+ *    Copyright (c) 2026, VRAI Labs and/or its affiliates. All rights reserved.
+ *
+ *    This software is licensed under the Apache License, Version 2.0 (the
+ *    "License") as published by the Apache Software Foundation.
+ *
+ *    You may not use this file except in compliance with the License. You may
+ *    obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *    License for the specific language governing permissions and limitations
+ *    under the License.
+ *
+ */
+
+package io.supertokens.storage.postgresql.test;
+
+import com.google.gson.JsonObject;
+import io.supertokens.storage.postgresql.config.PostgreSQLConfig;
+import io.supertokens.storage.postgresql.utils.ConfigMapper;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestRule;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+
+/**
+ * getConnectionPoolId() becomes the HikariCP pool name, which leaks into Hikari log lines,
+ * exception messages and telemetry exports. These tests pin the security property that the raw
+ * database password never appears in it, while still contributing to pool identity.
+ *
+ * Pure unit tests: getConnectionPoolId() only reflects over the config fields, so no running
+ * core or database is needed.
+ */
+public class ConnectionPoolIdTest {
+
+    @Rule
+    public TestRule watchman = Utils.getOnFailure();
+
+    private static PostgreSQLConfig configWithPassword(String password) throws Exception {
+        JsonObject json = new JsonObject();
+        json.addProperty("postgresql_user", "test_user");
+        json.addProperty("postgresql_password", password);
+        json.addProperty("postgresql_database_name", "supertokens");
+        return ConfigMapper.mapConfig(json, PostgreSQLConfig.class);
+    }
+
+    @Test
+    public void connectionPoolIdDoesNotContainRawPassword() throws Exception {
+        String password = "s3cr3t-Db-Passw0rd!";
+        String poolId = configWithPassword(password).getConnectionPoolId();
+
+        assertFalse(poolId.contains(password));
+    }
+
+    @Test
+    public void passwordStillContributesToConnectionPoolIdUniqueness() throws Exception {
+        // identical configs -> identical pool ids (pool reuse must keep working)
+        assertEquals(
+                configWithPassword("password-one").getConnectionPoolId(),
+                configWithPassword("password-one").getConnectionPoolId());
+
+        // configs identical except for the password -> different pool ids, so rotating the
+        // password still tears down and replaces the connection pool
+        assertNotEquals(
+                configWithPassword("password-one").getConnectionPoolId(),
+                configWithPassword("password-two").getConnectionPoolId());
+    }
+}


### PR DESCRIPTION
## Problem

`PostgreSQLConfig.getConnectionPoolId()` embeds the **raw** `postgresql_password` (wrapped in
`|db_pass|...|db_pass` markers). That string becomes the HikariCP pool name
(`ConnectionPool`: `setPoolName(userPoolId + "~" + connectionPoolId)`), so it appears in Hikari log
lines, in `SQLTransientConnectionException` messages, and anywhere those are forwarded.

Masking exists for the file/console appenders (`output/CustomLayout`, `output/Logging` via
`Utils.maskDBPassword`), but **the OpenTelemetry export path bypasses it**:
`HikariLoggingAppender.appendToOtel` passes `event.getFormattedMessage()` unmasked to
`otelProvider.createLogEvent`. Where telemetry export is enabled, database passwords are therefore
exported verbatim to the telemetry backend.

## Change

1. `getConnectionPoolId()` now contributes `sha256(password)` truncated to 12 hex characters instead
   of the password itself. Pool identity is only ever compared (never parsed), so uniqueness per
   credential set is preserved while the secret never enters the pool name - and therefore cannot
   reach logs, exception messages or telemetry by any route. The `|db_pass|...|db_pass` markers are
   kept so existing masking logic and log tooling keep working.
2. `HikariLoggingAppender.appendToOtel` applies `Utils.maskDBPassword`, matching the file/console
   appenders (defence in depth for anything else that ends up in those messages).

## Rollout note

The connection pool id changes, so each tenant's pool is recreated once after deploy. No API or
schema change.

## Follow-up (separate, core repo)

`io.supertokens.output.Logging` also calls `createLogEvent` with unmasked messages in five places -
cheapest fix is a single mask inside `TelemetryProvider.createLogEvent`.
