### PR TITLE
fix: single bucketed MAU query + backfill missing user_last_active index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+- Adds `countUsersActiveSinceGroupedByDay` (implements the new `ActiveUsersStorage` method): the MAU series is
+  now computed with a single bucketed query instead of one `COUNT(*)` per day threshold
+- Adds a composite `(app_id, last_active_time)` index on `user_last_active`, created on fresh databases and
+  backfilled (best-effort, outside the main DDL transaction) on databases provisioned before it existed
+
 ## [9.5.6]
 
 - Adds `SKIP LOCKED` to the backfill batch locking query to improve performance

--- a/src/main/java/io/supertokens/storage/postgresql/Start.java
+++ b/src/main/java/io/supertokens/storage/postgresql/Start.java
@@ -1888,6 +1888,16 @@ public class Start
     }
 
     @Override
+    public Map<Integer, Integer> countUsersActiveSinceGroupedByDay(AppIdentifier appIdentifier, long sinceTime,
+                                                                   long now) throws StorageQueryException {
+        try {
+            return ActiveUsersQueries.countUsersActiveSinceGroupedByDay(this, appIdentifier, sinceTime, now);
+        } catch (SQLException e) {
+            throw new StorageQueryException(e);
+        }
+    }
+
+    @Override
     public void deleteUserActive_Transaction(TransactionConnection con, AppIdentifier appIdentifier, String userId)
             throws StorageQueryException {
         try {

--- a/src/main/java/io/supertokens/storage/postgresql/queries/ActiveUsersQueries.java
+++ b/src/main/java/io/supertokens/storage/postgresql/queries/ActiveUsersQueries.java
@@ -38,9 +38,38 @@ public class ActiveUsersQueries {
                 + Config.getConfig(start).getUserLastActiveTable() + "(app_id);";
     }
 
+    public static String getQueryToCreateAppIdLastActiveTimeIndexForUserLastActiveTable(Start start) {
+        // (app_id, last_active_time): the MAU queries filter on both columns; the time-leading
+        // index below cannot serve them, so they degrade to sequential scans.
+        return "CREATE INDEX IF NOT EXISTS user_last_active_app_id_last_active_time_index ON "
+                + Config.getConfig(start).getUserLastActiveTable() + "(app_id, last_active_time);";
+    }
+
     public static String getQueryToCreateLastActiveTimeIndexForUserLastActiveTable(Start start) {
         return "CREATE INDEX IF NOT EXISTS user_last_active_last_active_time_index ON "
                 + Config.getConfig(start).getUserLastActiveTable() + "(last_active_time DESC, app_id DESC);";
+    }
+
+    public static Map<Integer, Integer> countUsersActiveSinceGroupedByDay(Start start, AppIdentifier appIdentifier,
+                                                                          long sinceTime, long now)
+            throws SQLException, StorageQueryException {
+        // One bounded pass instead of one COUNT(*) per threshold: bucket users by whole days since
+        // last activity. Callers rebuild the cumulative series in memory.
+        String QUERY = "SELECT FLOOR((? - last_active_time) / 86400000) AS days_ago, COUNT(*) AS c FROM "
+                + Config.getConfig(start).getUserLastActiveTable()
+                + " WHERE app_id = ? AND last_active_time >= ? GROUP BY days_ago";
+
+        return execute(start, QUERY, pst -> {
+            pst.setLong(1, now);
+            pst.setString(2, appIdentifier.getAppId());
+            pst.setLong(3, sinceTime);
+        }, result -> {
+            Map<Integer, Integer> buckets = new HashMap<>();
+            while (result.next()) {
+                buckets.put(result.getInt("days_ago"), result.getInt("c"));
+            }
+            return buckets;
+        });
     }
 
     public static int countUsersActiveSince(Start start, AppIdentifier appIdentifier, long sinceTime)

--- a/src/main/java/io/supertokens/storage/postgresql/queries/GeneralQueries.java
+++ b/src/main/java/io/supertokens/storage/postgresql/queries/GeneralQueries.java
@@ -395,6 +395,7 @@ public class GeneralQueries {
                     // Index
                     ddl.add(ActiveUsersQueries.getQueryToCreateAppIdIndexForUserLastActiveTable(start));
                     ddl.add(ActiveUsersQueries.getQueryToCreateLastActiveTimeIndexForUserLastActiveTable(start));
+                    ddl.add(ActiveUsersQueries.getQueryToCreateAppIdLastActiveTimeIndexForUserLastActiveTable(start));
                 }
 
                 // Backfill indexes for tables that ALREADY exist: the index DDL inside the blocks
@@ -835,7 +836,6 @@ public class GeneralQueries {
      * and committing makes the batch all-or-nothing; the existing retry-on-missing-schema
      * loop in {@link #createTablesIfNotExists} then sees a clean state to retry against.
      */
-
     private static void executeDDLBatch(Connection con, List<String> statements) throws SQLException {
         if (statements.isEmpty()) {
             return;

--- a/src/main/java/io/supertokens/storage/postgresql/queries/GeneralQueries.java
+++ b/src/main/java/io/supertokens/storage/postgresql/queries/GeneralQueries.java
@@ -19,6 +19,7 @@ package io.supertokens.storage.postgresql.queries;
 import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import io.supertokens.storage.postgresql.output.Logging;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashMap;
@@ -394,6 +395,22 @@ public class GeneralQueries {
                     // Index
                     ddl.add(ActiveUsersQueries.getQueryToCreateAppIdIndexForUserLastActiveTable(start));
                     ddl.add(ActiveUsersQueries.getQueryToCreateLastActiveTimeIndexForUserLastActiveTable(start));
+                }
+
+                // Backfill indexes for tables that ALREADY exist: the index DDL inside the blocks
+                // above only ever runs when a table is first created, so databases provisioned
+                // before an index was introduced never receive it.
+                //
+                // These are deliberately NOT added to `ddl`: executeDDLBatch runs the whole list in
+                // one transaction and rolls back on any failure, so a slow index build hitting a
+                // lock/statement timeout on a large table would abort table creation for everyone
+                // else and prevent the core from starting. They are executed separately and
+                // failures are logged, not propagated - a missing index degrades performance, it
+                // does not break correctness, and the next boot retries.
+                List<String> backfillIndexDdl = new ArrayList<>();
+                if (doesTableExists(existingTables, Config.getConfig(start).getUserLastActiveTable())) {
+                    backfillIndexDdl.add(
+                            ActiveUsersQueries.getQueryToCreateAppIdLastActiveTimeIndexForUserLastActiveTable(start));
                 }
 
                 if (!doesTableExists(existingTables, Config.getConfig(start).getAccessTokenSigningKeysTable())) {
@@ -788,6 +805,7 @@ public class GeneralQueries {
                 }
 
                 executeDDLBatch(con, ddl);
+                executeBackfillIndexDDL(con, backfillIndexDdl, start);
 
             } catch (Exception e) {
                 if (e.getMessage().contains("schema") && e.getMessage().contains("does not exist")
@@ -817,6 +835,7 @@ public class GeneralQueries {
      * and committing makes the batch all-or-nothing; the existing retry-on-missing-schema
      * loop in {@link #createTablesIfNotExists} then sees a clean state to retry against.
      */
+
     private static void executeDDLBatch(Connection con, List<String> statements) throws SQLException {
         if (statements.isEmpty()) {
             return;
@@ -849,6 +868,37 @@ public class GeneralQueries {
                 try {
                     con.setAutoCommit(true);
                 } catch (SQLException ignored) {
+                }
+            }
+        }
+    }
+
+    /**
+     * Runs "CREATE INDEX IF NOT EXISTS" statements that backfill indexes onto pre-existing tables.
+     * Each statement gets its own transaction and its own error handling: these are optimisations,
+     * so a failure (lock timeout on a big table, insufficient privileges, ...) must never prevent
+     * the core from starting or roll back the main DDL batch. The next boot retries.
+     */
+    private static void executeBackfillIndexDDL(Connection con, List<String> statements, Start start) {
+        for (String sql : statements) {
+            boolean previousAutoCommit;
+            try {
+                previousAutoCommit = con.getAutoCommit();
+                con.setAutoCommit(true);
+            } catch (SQLException e) {
+                Logging.debug(start, "Skipping index backfill, could not set autocommit: " + e.getMessage());
+                return;
+            }
+            try (var stmt = con.createStatement()) {
+                stmt.execute(sql);
+            } catch (SQLException e) {
+                Logging.debug(start, "Index backfill skipped (will retry on next start): " + sql
+                        + " - " + e.getMessage());
+            } finally {
+                try {
+                    con.setAutoCommit(previousAutoCommit);
+                } catch (SQLException ignored) {
+                    // best effort
                 }
             }
         }

--- a/src/test/java/io/supertokens/storage/postgresql/test/ActiveUsersBucketedQueryTest.java
+++ b/src/test/java/io/supertokens/storage/postgresql/test/ActiveUsersBucketedQueryTest.java
@@ -1,0 +1,170 @@
+/*
+ *    Copyright (c) 2026, VRAI Labs and/or its affiliates. All rights reserved.
+ *
+ *    This software is licensed under the Apache License, Version 2.0 (the
+ *    "License") as published by the Apache Software Foundation.
+ *
+ *    You may not use this file except in compliance with the License. You may
+ *    obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *    License for the specific language governing permissions and limitations
+ *    under the License.
+ *
+ */
+
+package io.supertokens.storage.postgresql.test;
+
+import io.supertokens.ProcessState;
+import io.supertokens.pluginInterface.STORAGE_TYPE;
+import io.supertokens.pluginInterface.multitenancy.AppIdentifier;
+import io.supertokens.storage.postgresql.Start;
+import io.supertokens.storage.postgresql.config.Config;
+import io.supertokens.storageLayer.StorageLayer;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestRule;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+public class ActiveUsersBucketedQueryTest {
+
+    private static final long DAY = 24 * 3600 * 1000L;
+
+    @Rule
+    public TestRule watchman = Utils.getOnFailure();
+
+    @AfterClass
+    public static void afterTesting() {
+        Utils.afterTesting();
+    }
+
+    @Before
+    public void beforeEach() {
+        Utils.reset();
+    }
+
+    /**
+     * countUsersActiveSinceGroupedByDay replaces one countUsersActiveSince call per day threshold.
+     * This pins the equivalence: for every i in 0..30, the running total of buckets 0..i must equal
+     * countUsersActiveSince(now - (i+1) days).
+     */
+    @Test
+    public void bucketedCountsMatchPerThresholdCounts() throws Exception {
+        String[] args = {"../"};
+
+        TestingProcessManager.TestingProcess process = TestingProcessManager.start(args);
+        assertNotNull(process.checkOrWaitForEvent(ProcessState.PROCESS_STATE.STARTED));
+
+        if (StorageLayer.getStorage(process.getProcess()).getType() != STORAGE_TYPE.SQL) {
+            process.kill();
+            assertNotNull(process.checkOrWaitForEvent(ProcessState.PROCESS_STATE.STOPPED));
+            return;
+        }
+
+        Start storage = (Start) StorageLayer.getStorage(process.getProcess());
+        AppIdentifier appIdentifier = new AppIdentifier(null, null);
+        long now = System.currentTimeMillis();
+
+        // users per "days ago" bucket; buckets 2..4 and 6..28 stay empty on purpose, and the
+        // bucket-33 user lies beyond the 31-day window so it must be filtered out by sinceTime
+        Map<Integer, Integer> seeded = new LinkedHashMap<>();
+        seeded.put(0, 3);
+        seeded.put(1, 2);
+        seeded.put(5, 1);
+        seeded.put(29, 1);
+        seeded.put(30, 2);
+        seeded.put(33, 1);
+
+        int userCounter = 0;
+        for (Map.Entry<Integer, Integer> entry : seeded.entrySet()) {
+            for (int i = 0; i < entry.getValue(); i++) {
+                // mid-bucket timestamp, so no FLOOR boundary flakiness
+                long lastActiveTime = now - entry.getKey() * DAY - DAY / 2;
+                storage.updateLastActive(appIdentifier, "bucketed-user-" + (userCounter++), lastActiveTime);
+            }
+        }
+
+        long sinceTime = now - 31 * DAY;
+        Map<Integer, Integer> buckets = storage.countUsersActiveSinceGroupedByDay(appIdentifier, sinceTime, now);
+
+        // the user last active 33 days ago is outside the window and must not show up at all
+        assertFalse(buckets.containsKey(33));
+
+        int runningTotal = 0;
+        for (int i = 0; i <= 30; i++) {
+            runningTotal += buckets.getOrDefault(i, 0);
+            assertEquals("active-since count mismatch for the " + (i + 1) + "-day threshold",
+                    storage.countUsersActiveSince(appIdentifier, now - (i + 1) * DAY), runningTotal);
+        }
+
+        // everything inside the window is accounted for exactly once across the buckets
+        assertEquals(storage.countUsersActiveSince(appIdentifier, sinceTime),
+                buckets.values().stream().mapToInt(Integer::intValue).sum());
+
+        process.kill();
+        assertNotNull(process.checkOrWaitForEvent(ProcessState.PROCESS_STATE.STOPPED));
+    }
+
+    /**
+     * The composite (app_id, last_active_time) index must be created for FRESH databases by
+     * createTablesIfNotExists, not only backfilled onto pre-existing ones. This pins the
+     * regression where it was only emitted in the backfill path (gated on the table already
+     * existing), so fresh databases never got it until a second restart.
+     */
+    @Test
+    public void compositeIndexIsCreatedOnFreshDatabase() throws Exception {
+        String[] args = {"../"};
+
+        TestingProcessManager.TestingProcess process = TestingProcessManager.start(args);
+        assertNotNull(process.checkOrWaitForEvent(ProcessState.PROCESS_STATE.STARTED));
+
+        if (StorageLayer.getStorage(process.getProcess()).getType() != STORAGE_TYPE.SQL) {
+            process.kill();
+            assertNotNull(process.checkOrWaitForEvent(ProcessState.PROCESS_STATE.STOPPED));
+            return;
+        }
+
+        Start storage = (Start) StorageLayer.getStorage(process.getProcess());
+
+        // getUserLastActiveTable() may be schema-qualified; pg_indexes.tablename is not
+        String table = Config.getConfig(storage).getUserLastActiveTable();
+        String tableName = table.contains(".") ? table.substring(table.lastIndexOf('.') + 1) : table;
+
+        List<String> indexNames = storage.startTransaction(con -> {
+            Connection sqlCon = (Connection) con.getConnection();
+            List<String> result = new ArrayList<>();
+            try (PreparedStatement pst = sqlCon
+                    .prepareStatement("SELECT indexname FROM pg_indexes WHERE tablename = ?")) {
+                pst.setString(1, tableName);
+                try (ResultSet rs = pst.executeQuery()) {
+                    while (rs.next()) {
+                        result.add(rs.getString("indexname"));
+                    }
+                }
+            }
+            return result;
+        });
+
+        assertTrue("missing composite index on fresh DB, found only: " + indexNames,
+                indexNames.contains("user_last_active_app_id_last_active_time_index"));
+
+        process.kill();
+        assertNotNull(process.checkOrWaitForEvent(ProcessState.PROCESS_STATE.STOPPED));
+    }
+}


### PR DESCRIPTION
## Problem

`GET /appid-<app>/ee/featureflag` recomputes `getPaidFeatureStats()` on every call (only
`getEnabledFeatures` is cached). The dominant cost is `getMAUs()`, which issues **31 sequential
`COUNT(*)` queries** - one per day threshold - each on its own pooled connection:

```sql
SELECT COUNT(*) FROM user_last_active WHERE app_id = ? AND last_active_time >= ?
```

The 31 queries overlap almost entirely (the 31-day query re-counts everything the 1-day query
counted), and `user_last_active` has no `(app_id, last_active_time)` index - only `(app_id)`, the PK,
and a time-leading `(last_active_time DESC, app_id DESC)` - so they degrade to sequential scans.

`EXPLAIN (ANALYZE, BUFFERS)` on eight production databases (114k-628k rows in `user_last_active`):
each count costs 46-579 ms and the 31-query loop accounts for the endpoint's full 1.4-3 s response
time. It is polled on a fixed schedule, so this runs continuously on every shared core.

Separately: the index DDL for `user_last_active` only ever runs inside
`if (!doesTableExists(...))`, so **databases created before an index was introduced never receive
it**. Of the eight databases inspected, none had the composite index and six had no
`last_active_time` index at all.

## Change

**`ActiveUsersStorage`** (internal interface): add
`countUsersActiveSinceGroupedByDay(appIdentifier, sinceTime, now)` returning
`Map<daysAgo, userCount>`.

**postgresql-plugin**
- `ActiveUsersQueries.countUsersActiveSinceGroupedByDay`: one bounded query
  ```sql
  SELECT FLOOR((? - last_active_time) / 86400000) AS days_ago, COUNT(*)
    FROM user_last_active WHERE app_id = ? AND last_active_time >= ? GROUP BY days_ago
  ```
- New index `user_last_active_app_id_last_active_time_index (app_id, last_active_time)`.
- `GeneralQueries` now also emits that index for **already existing** tables. These statements are
  deliberately kept **out of** the main `executeDDLBatch` list: that batch runs in a single
  transaction and rolls back on any failure, so a slow index build hitting a lock/statement timeout
  would abort table creation and prevent startup. A new `executeBackfillIndexDDL` runs each statement
  in its own autocommit transaction and logs failures instead of throwing - a missing index degrades
  performance but does not break correctness, and the next start retries.

**core**
- `EEFeatureFlag.getMAUs()`: one call plus a running total. `maus[i]` (users active since
  `now - (i+1) days`) is by definition the cumulative sum of buckets `0..i`, so the output array is
  identical.
- `inmemorydb` implements the new method (derives buckets from the existing count API).
- `getSAMLStats()` bug fixes: `stat.add(tenantId, stat)` added the object **to itself** (a JSON
  serialization recursion hazard for SAML-enabled apps), and `tenantStat` was never appended to
  `tenantStats`, so `"tenants"` was always an empty array.

## Measured effect

The bucketed query costs about the same as a **single** 31-day count on every database inspected
(e.g. 493 ms vs 424 ms on the largest, 180 ms vs 180 ms, 67 ms vs 49 ms), i.e. roughly a 20-30x
reduction in database work per poll, plus 31 -> 1 connection acquisitions.

## Rollout note

On large tables the index build blocks writes for its duration. Recommended: create it out of band
first with `CREATE INDEX CONCURRENTLY IF NOT EXISTS user_last_active_app_id_last_active_time_index ON
user_last_active (app_id, last_active_time);` on the biggest databases, then deploy.

## Testing

- The `maus` array from `/ee/featureflag` must be identical before and after (pure refactor of the
  same counts) - diff the arrays on a database with activity.
- `\d user_last_active` shows the new index after start.
- For a SAML-enabled app, `usageStats.saml.tenants` is now populated (was always `[]`).

## Merge order

`supertokens-plugin-interface` first, then `supertokens-postgresql-plugin`, then `supertokens-core`.
